### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,7 +57,7 @@ Features
 Documentation
 =============
 
-The full documentation is available at https://overloading.readthedocs.org/.
+The full documentation is available at https://overloading.readthedocs.io/.
 
 
 Installation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,7 @@ _basename = 'overloading'
 _title = 'overloading.py documentation'
 _subtitle = 'Function overloading for Python 3'
 _project_url = 'https://github.com/bintoro/overloading.py'
-_doc_url = 'https://overloading.readthedocs.org'
+_doc_url = 'https://overloading.readthedocs.io'
 
 version = __version__
 release = __version__

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Notable changes since v0.4
 
 
 .. include:: ../README.rst
-   :start-after: https://overloading.readthedocs.org/.
+   :start-after: https://overloading.readthedocs.io/.
 
 
 Links

--- a/overloading.py
+++ b/overloading.py
@@ -6,7 +6,7 @@ overloading.py
 Function overloading for Python 3
 
 * Project repository: https://github.com/bintoro/overloading.py
-* Documentation: https://overloading.readthedocs.org/
+* Documentation: https://overloading.readthedocs.io/
 
 Copyright © 2014–2016 Kalle Tuure. Released under the MIT License.
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.